### PR TITLE
Fix: Use math.sin in mock sensor interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .env.development
 .env.test
 .env.production
+
+# Python
+__pycache__/

--- a/sensor_interface.py
+++ b/sensor_interface.py
@@ -7,6 +7,7 @@ import os
 import time
 import logging
 import random
+import math
 from abc import ABC, abstractmethod
 from typing import Optional, Tuple
 
@@ -150,7 +151,7 @@ class MockSensorInterface(SensorInterface):
         """Generate mock temperature with realistic variation."""
         # Simulate daily temperature cycle and random variation
         elapsed = time.time() - self._start_time
-        daily_cycle = 2.0 * (0.5 + 0.5 * (time.sin(elapsed / 3600.0 * 2 * 3.14159 / 24)))  # 24-hour cycle
+        daily_cycle = 2.0 * (0.5 + 0.5 * (math.sin(elapsed / 3600.0 * 2 * math.pi / 24)))  # 24-hour cycle
         random_variation = random.uniform(-0.5, 0.5)
         return self._base_temp + daily_cycle + random_variation
     
@@ -158,7 +159,7 @@ class MockSensorInterface(SensorInterface):
         """Generate mock humidity with realistic variation."""
         # Simulate humidity changes with random variation
         elapsed = time.time() - self._start_time
-        slow_variation = 10.0 * (0.5 + 0.5 * (time.sin(elapsed / 7200.0)))  # 2-hour cycle
+        slow_variation = 10.0 * (0.5 + 0.5 * (math.sin(elapsed / 7200.0)))  # 2-hour cycle
         random_variation = random.uniform(-2.0, 2.0)
         humidity = self._base_humidity + slow_variation + random_variation
         return max(20.0, min(80.0, humidity))  # Clamp between 20-80%

--- a/test_sensor_interface.py
+++ b/test_sensor_interface.py
@@ -1,0 +1,28 @@
+import unittest
+import math
+from sensor_interface import MockSensorInterface
+
+class TestMockSensorInterface(unittest.TestCase):
+
+    def test_get_temperature_uses_math_sin(self):
+        """Test that get_temperature runs without raising an error and uses math.sin."""
+        try:
+            sensor = MockSensorInterface()
+            # This will now use math.sin and should not raise an AttributeError
+            temp = sensor.get_temperature()
+            self.assertIsInstance(temp, float)
+        except Exception as e:
+            self.fail(f"get_temperature raised an unexpected exception: {e}")
+
+    def test_get_humidity_uses_math_sin(self):
+        """Test that get_humidity runs without raising an error and uses math.sin."""
+        try:
+            sensor = MockSensorInterface()
+            # This will now use math.sin and should not raise an AttributeError
+            humidity = sensor.get_humidity()
+            self.assertIsInstance(humidity, float)
+        except Exception as e:
+            self.fail(f"get_humidity raised an unexpected exception: {e}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The `MockSensorInterface` in `sensor_interface.py` was using `time.sin` to generate mock sensor data. The `time` module does not have a `sin` function, which caused an `AttributeError` when using the mock sensors.

This commit fixes the bug by importing the `math` module and using `math.sin` instead of `time.sin`. It also replaces a hardcoded value of pi with `math.pi` for better accuracy and readability.

A new test file, `test_sensor_interface.py`, has been added with tests that verify the `get_temperature` and `get_humidity` methods of the `MockSensorInterface` no longer raise an `AttributeError`.

The `.gitignore` file has also been updated to ignore `__pycache__` directories.