### PR TITLE
Update Dockerfile and wsgi.py to simplify waitress-serve command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD python -c "import requests; requests.get('http://localhost:8080/health', timeout=5)" || exit 1
 
 # Use Waitress for production deployment
-CMD ["waitress-serve", "--host=0.0.0.0", "--port=8080", "--threads=1", "--channel-timeout=120", "--call", "wsgi:app"]
+CMD ["waitress-serve", "--host=0.0.0.0", "--port=8080", "--threads=1", "--channel-timeout=120", "wsgi:app"]

--- a/wsgi.py
+++ b/wsgi.py
@@ -5,10 +5,10 @@ This module provides the Flask application and sensor thread initialization
 for use with Waitress or other WSGI servers.
 
 Usage:
-    waitress-serve --host=0.0.0.0 --port=8080 --threads=1 --call wsgi:app
+    waitress-serve --host=0.0.0.0 --port=8080 --threads=1 wsgi:app
 
 Or in docker-compose.yml:
-    CMD ["waitress-serve", "--host=0.0.0.0", "--port=8080", "--threads=1", "--call", "wsgi:app"]
+    CMD ["waitress-serve", "--host=0.0.0.0", "--port=8080", "--threads=1", "wsgi:app"]
 """
 
 import logging


### PR DESCRIPTION
- Removed the '--call' option from the CMD instruction in both Dockerfile and wsgi.py for cleaner command usage.
- Updated usage instructions in wsgi.py to reflect the change in command syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production server configuration documentation and examples. No functional changes or performance impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->