### PR TITLE
Refactor Cloudflare Tunnel setup in README and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           # Create .env file with required configuration
           echo "BEARER_TOKEN=${BEARER_TOKEN}" > .env
 
-          # Add optional Cloudflare Tunnel token if configured
+          # Add required Cloudflare Tunnel token
           if [ -n "${CLOUDFLARED_TOKEN}" ]; then
             echo "CLOUDFLARED_TOKEN=${CLOUDFLARED_TOKEN}" >> .env
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             exit 1
           fi
 
-          # Validate CLOUDFLARED_TOKEN (required since we deploy with cloudflare profile)
+          # Validate CLOUDFLARED_TOKEN (required for cloudflared tunnel service)
           if [ -z "${CLOUDFLARED_TOKEN}" ]; then
             echo "Missing required secret: CLOUDFLARED_TOKEN"
             exit 1
@@ -116,4 +116,4 @@ jobs:
         run: mkdir -p logs
 
       - name: Deploy with Docker Compose
-        run: docker compose -p temp-monitor --profile cloudflare up -d --build --remove-orphans
+        run: docker compose -p temp-monitor up -d --build --remove-orphans

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ docker compose down
 
 **Note**: Requires privileged mode for I2C/hardware access.
 
-**Cloudflare Tunnel (Optional):** To enable the bundled Cloudflare Tunnel:
+**Cloudflare Tunnel:** The bundled Cloudflare Tunnel service starts automatically:
 1. Add `CLOUDFLARED_TOKEN` to `.env`
-2. Start with the cloudflare profile: `docker compose --profile cloudflare up -d`
+2. Start with: `docker compose up -d`
 3. In Cloudflare Zero Trust UI, point the tunnel service at `http://temp-monitor:8080`
 
 ### Systemd Service

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All configuration is done via environment variables in `.env`. Copy `.env.exampl
 |----------|---------|-------------|
 | `BEARER_TOKEN` | (required) | API authentication token |
 | `LOG_FILE` | `temp_monitor.log` | Log file path |
-| `CLOUDFLARED_TOKEN` | (none) | Cloudflare Tunnel token for docker-compose `cloudflared` service |
+| `CLOUDFLARED_TOKEN` | (required) | Cloudflare Tunnel token for docker-compose `cloudflared` service |
 
 ### Webhook Settings
 
@@ -228,10 +228,12 @@ docker compose down
 
 **Note**: Requires privileged mode for I2C/hardware access.
 
-**Cloudflare Tunnel:** The bundled Cloudflare Tunnel service starts automatically:
+**Cloudflare Tunnel:** The bundled Cloudflare Tunnel service starts automatically (requires `CLOUDFLARED_TOKEN`):
 1. Add `CLOUDFLARED_TOKEN` to `.env`
 2. Start with: `docker compose up -d`
 3. In Cloudflare Zero Trust UI, point the tunnel service at `http://temp-monitor:8080`
+
+**Note:** If `CLOUDFLARED_TOKEN` is not set, the cloudflared service will fail to start, but the main temp-monitor service will continue working. To run without Cloudflare Tunnel, use `docker compose up -d temp-monitor`.
 
 ### Systemd Service
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All configuration is done via environment variables in `.env`. Copy `.env.exampl
 |----------|---------|-------------|
 | `BEARER_TOKEN` | (required) | API authentication token |
 | `LOG_FILE` | `temp_monitor.log` | Log file path |
-| `CLOUDFLARED_TOKEN` | (required) | Cloudflare Tunnel token for docker-compose `cloudflared` service |
+| `CLOUDFLARED_TOKEN` | (required for CI) | Cloudflare Tunnel token for docker-compose `cloudflared` service (optional for local dev) |
 
 ### Webhook Settings
 
@@ -228,12 +228,12 @@ docker compose down
 
 **Note**: Requires privileged mode for I2C/hardware access.
 
-**Cloudflare Tunnel:** The bundled Cloudflare Tunnel service starts automatically (requires `CLOUDFLARED_TOKEN`):
+**Cloudflare Tunnel:** The bundled Cloudflare Tunnel service starts automatically:
 1. Add `CLOUDFLARED_TOKEN` to `.env`
 2. Start with: `docker compose up -d`
 3. In Cloudflare Zero Trust UI, point the tunnel service at `http://temp-monitor:8080`
 
-**Note:** If `CLOUDFLARED_TOKEN` is not set, the cloudflared service will fail to start, but the main temp-monitor service will continue working. To run without Cloudflare Tunnel, use `docker compose up -d temp-monitor`.
+**Note:** `CLOUDFLARED_TOKEN` is **required for CI/production** - the CI workflow (`.github/workflows/ci.yml:79-83`) enforces this and will fail deployment if missing. For **local development**, the token is optional: if not set, the cloudflared service will fail to start but the main temp-monitor service continues working. To run locally without Cloudflare Tunnel, use `docker compose up -d temp-monitor`.
 
 ### Systemd Service
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,3 @@ services:
     depends_on:
       - temp-monitor
     restart: unless-stopped
-    profiles:
-      - cloudflare


### PR DESCRIPTION
- Updated README to clarify the automatic start of the Cloudflare Tunnel service and simplified the startup command.
- Adjusted CI workflow to remove the cloudflare profile specification during deployment, ensuring a more straightforward process.
- Retained the restart policy in docker-compose.yml for the tunnel service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed and clarified Cloudflare Tunnel docs: tunnel described as required for CI/production (CLOUDFLARED_TOKEN) while optional for local development; deployment instructions simplified to use standard compose up; note added that main service continues if tunnel fails to start without a token.

* **Chores**
  * Removed profile gating so the tunnel service starts automatically during standard deployments; token handling and runtime behavior unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->